### PR TITLE
Pass through style prop

### DIFF
--- a/src/Picture.js
+++ b/src/Picture.js
@@ -248,16 +248,14 @@ export default class Picture extends Component {
   render() {
     const { sources, options, ...props } = this.props
 
-    let component = this.renderImage(props)
-
-    if (sources) {
-      component = (
-        <picture>
-          {this.renderSources()}
-          {this.renderImage(props, true)}
-        </picture>
-      )
-    }
+    const component = sources ? (
+      <picture>
+        {this.renderSources()}
+        {this.renderImage(props, true)}
+      </picture>
+    ) : (
+      this.renderImage(props)
+    )
 
     return (
       <Observer {...options} onChange={this.handleIntersection}>

--- a/src/Picture.js
+++ b/src/Picture.js
@@ -218,6 +218,7 @@ export default class Picture extends Component {
       filter,
       transitionTime,
       timingFunction,
+      style = {},
       ...props
     },
     skipSizes = false
@@ -238,6 +239,7 @@ export default class Picture extends Component {
         style={{
           filter: filter || `blur(${blur}px) grayscale(${grayscale}) opacity(${opacity})`,
           transition: `filter ${transitionTime}ms ${timingFunction}`,
+          ...style,
         }}
       />
     )


### PR DESCRIPTION
This is currently the only `img` property that cannot be passed through.

Also don't call `renderImage` twice if using `sources` 😃 